### PR TITLE
CMakeLists bug and name convention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
+find_package(ament_cmake REQUIRED)
+
 add_library(
-    NMEA2000_socketCAN SHARED
+    nmea2000_socketCAN
     NMEA2000_SocketCAN.cpp
     NMEA2000_SocketCAN.h
 )
 
-target_link_libraries(NMEA2000_socketCAN PUBLIC nmea2000)
-target_include_directories(NMEA2000_socketCAN PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(nmea2000_socketCAN PUBLIC nmea2000)
+target_include_directories(nmea2000_socketCAN PUBLIC "${CMAKE_SOURCE_DIR}/lib/NMEA2000/src")
+target_include_directories(nmea2000_socketCAN PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
* removed library type specifier SHARED
* make library target names consistent

I have encountered a bug while compiling, stating undefined functions. This change to the CMakeLists fixes the issue.